### PR TITLE
Add component-id to the response, wrap content-data in data-attribute

### DIFF
--- a/Controller/ContentController.php
+++ b/Controller/ContentController.php
@@ -7,12 +7,13 @@ use Kwf_Component_Data_Root;
 use Kwc\ContentApiBundle\Services\ContentBuilder;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Kwc\ContentApiBundle\Services\ContentBuilderInterface;
 
 class ContentController
 {
     private $contentBuilder;
 
-    public function __construct(ContentBuilder $contentBuilder)
+    public function __construct(ContentBuilderInterface $contentBuilder)
     {
         $this->contentBuilder = $contentBuilder;
     }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,7 +1,7 @@
 services:
     kwc_content_api.content_controller:
         class:    Kwc\ContentApiBundle\Controller\ContentController
-        autowire: true
+        arguments: ['@kwc_content_api.content_builder']
 
     kwc_content_api.content_builder:
         class:    Kwc\ContentApiBundle\Services\ContentBuilder

--- a/Services/ContentBuilder.php
+++ b/Services/ContentBuilder.php
@@ -4,7 +4,7 @@ namespace Kwc\ContentApiBundle\Services;
 use Kwc_Abstract;
 use Kwf_Component_Data;
 
-class ContentBuilder
+class ContentBuilder implements ContentBuilderInterface
 {
     private $exportComponents;
 
@@ -18,19 +18,21 @@ class ContentBuilder
         if (Kwc_Abstract::hasSetting($data->componentClass, 'apiContent') && in_array($data->componentClass, $this->exportComponents)) {
             $cls = Kwc_Abstract::getSetting($data->componentClass, 'apiContent');
             $apiContent = new $cls();
-            $ret = $apiContent->getContent($data);
-            if ($ret instanceof Kwf_Component_Data) {
-                $ret = $this->getContent($ret);
+            $contentData = $apiContent->getContent($data);
+            if ($contentData instanceof Kwf_Component_Data) {
+                $ret = $this->getContent($contentData);
             } else {
                 $ret['type'] = Kwc_Abstract::getSetting($data->componentClass, 'apiContentType');
+                $ret['id'] = $data->componentId;
+                $ret['data'] = $this->convertData($contentData);
             }
-
-
-            $ret = $this->convertData($ret);
         } else {
             $ret = array();
-            $ret['html'] = $data->render();
+            $ret['data'] = array(
+                'html' => $data->render()
+            );
             $ret['type'] = 'legacyHtml';
+            $ret['id'] = $data->componentId;
         }
         return $ret;
     }

--- a/Services/ContentBuilderInterface.php
+++ b/Services/ContentBuilderInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace Kwc\ContentApiBundle\Services;
+
+use Kwf_Component_Data;
+
+interface ContentBuilderInterface
+{
+    public function getContent(Kwf_Component_Data $data);
+}


### PR DESCRIPTION
Each component returns now id, type and data. Prevents namespace clash ("type" can now be used as content data attribute). Data-structure can now be easier consumed with typescript. React can more efficiently keep track of data-changes with a unique id (We can now use id as key-attribute instead of index in loop-structures).